### PR TITLE
Resolve Coverity 1093431 & 1093432

### DIFF
--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -4558,7 +4558,7 @@ void multi_pxo_pinfo_build_vals()
 
 	// primary friendly hit %
 	memset(Multi_pxo_pinfo_vals[15], 0, 50);
-	if (fs->stats.p_shots_hit > 0) {		
+	if (fs->stats.p_shots_fired > 0) {		
 	   sprintf(Multi_pxo_pinfo_vals[15], "%d%%", (int)((float)100.0f*((float)fs->stats.p_bonehead_hits/(float)fs->stats.p_shots_fired)));
 	} else {		
 		strcpy_s(Multi_pxo_pinfo_vals[15], "0%");
@@ -4570,7 +4570,7 @@ void multi_pxo_pinfo_build_vals()
 
 	// secondary friendly hit %
 	memset(Multi_pxo_pinfo_vals[17], 0, 50);
-	if (fs->stats.s_shots_hit > 0) {
+	if (fs->stats.s_shots_fired > 0) {
 	   sprintf(Multi_pxo_pinfo_vals[17], "%d%%", (int)((float)100.0f*((float)fs->stats.s_bonehead_hits/(float)fs->stats.s_shots_fired)));
 	} else {		
 		strcpy_s(Multi_pxo_pinfo_vals[17], "0%");


### PR DESCRIPTION
Should resolve issues 1093431 and 1093432. Same logic used in CID's 1093428 & 1093429.  These issues cannot cause crashes, but they're useful to resolve to get coverity and other future diagnosing programs to stop yelling at us.